### PR TITLE
[フェーズ3] FOV - 視野システムと探索

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -3,9 +3,9 @@ pub mod state;
 
 use crate::{
     entity::player::Player,
-    world::{dungeon::Dungeon, tile::TileType},
+    world::{dungeon::Dungeon, fov::Fov, tile::TileType},
 };
-use config::MAX_DEPTH;
+use config::{FOV_RADIUS, MAX_DEPTH};
 use state::GameState;
 
 pub struct Game {
@@ -13,18 +13,22 @@ pub struct Game {
     pub dungeon: Dungeon,
     pub player: Player,
     pub running: bool,
+    pub fov: Fov,
 }
 
 impl Game {
     pub fn new() -> Self {
         let dungeon = Dungeon::new_random(1);
         let player = Player::new(dungeon.player_start);
+        let mut fov = Fov::new(FOV_RADIUS);
+        fov.calculate(player.position, &dungeon);
 
         Game {
             state: GameState::default(),
             dungeon,
             player,
             running: true,
+            fov,
         }
     }
 
@@ -33,6 +37,7 @@ impl Game {
 
         if self.dungeon.is_walkable(new_pos) {
             self.player.position = new_pos;
+            self.fov.calculate(self.player.position, &self.dungeon);
         }
     }
 
@@ -48,6 +53,8 @@ impl Game {
             if new_depth <= MAX_DEPTH {
                 self.dungeon = Dungeon::new_random(new_depth);
                 self.player.position = self.dungeon.player_start;
+                self.fov = Fov::new(FOV_RADIUS);
+                self.fov.calculate(self.player.position, &self.dungeon);
             }
         }
     }

--- a/src/game/config.rs
+++ b/src/game/config.rs
@@ -10,3 +10,6 @@ pub const MAX_ROOM_SIZE: i32 = 10;
 
 /// Dungeon depth
 pub const MAX_DEPTH: u32 = 10;
+
+/// Field of View radius
+pub const FOV_RADIUS: i32 = 8;

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,7 +1,9 @@
 pub mod dungeon;
+pub mod fov;
 pub mod generator;
 pub mod tile;
 
 pub use dungeon::Dungeon;
+pub use fov::Fov;
 pub use generator::Room;
 pub use tile::TileType;

--- a/src/world/dungeon.rs
+++ b/src/world/dungeon.rs
@@ -223,6 +223,13 @@ impl Dungeon {
     pub fn is_walkable(&self, pos: Position) -> bool {
         self.get_tile(pos).is_some_and(|t| t.is_walkable())
     }
+
+    /// Returns true if the tile at the position allows light to pass through.
+    /// Walls block light, while floors and stairs are transparent.
+    pub fn is_transparent(&self, pos: Position) -> bool {
+        self.get_tile(pos)
+            .is_some_and(|t| matches!(t, TileType::Floor | TileType::StairsDown))
+    }
 }
 
 #[cfg(test)]
@@ -415,6 +422,46 @@ mod tests {
         assert!(
             dungeon.is_walkable(dungeon.stairs_position),
             "Stairs position should be walkable"
+        );
+    }
+
+    // ===== Transparency tests (Phase 3 - FOV) =====
+
+    #[test]
+    fn test_wall_not_transparent() {
+        let dungeon = Dungeon::new_fixed();
+        // Corner (0,0) is always a wall
+        assert!(
+            !dungeon.is_transparent(Position { x: 0, y: 0 }),
+            "Wall should not be transparent"
+        );
+    }
+
+    #[test]
+    fn test_floor_transparent() {
+        let dungeon = Dungeon::new_fixed();
+        // Player start is always floor
+        assert!(
+            dungeon.is_transparent(dungeon.player_start),
+            "Floor should be transparent"
+        );
+    }
+
+    #[test]
+    fn test_stairs_transparent() {
+        let dungeon = Dungeon::new_random(1);
+        assert!(
+            dungeon.is_transparent(dungeon.stairs_position),
+            "Stairs should be transparent"
+        );
+    }
+
+    #[test]
+    fn test_outside_bounds_not_transparent() {
+        let dungeon = Dungeon::new_fixed();
+        assert!(
+            !dungeon.is_transparent(Position { x: -1, y: 0 }),
+            "Outside bounds should not be transparent"
         );
     }
 }

--- a/src/world/fov.rs
+++ b/src/world/fov.rs
@@ -1,0 +1,229 @@
+//! Field of View (FOV) calculation module
+//!
+//! Uses recursive shadowcasting algorithm to calculate
+//! which tiles are visible from the player's position.
+
+use crate::entity::position::Position;
+use crate::world::dungeon::Dungeon;
+use std::collections::HashSet;
+
+/// Manages field of view state
+pub struct Fov {
+    /// Currently visible tiles
+    visible: HashSet<(i32, i32)>,
+    /// Previously explored tiles (persist across moves)
+    explored: HashSet<(i32, i32)>,
+    /// FOV radius
+    radius: i32,
+}
+
+impl Fov {
+    /// Creates a new FOV with the given radius
+    pub fn new(radius: i32) -> Self {
+        Self {
+            visible: HashSet::new(),
+            explored: HashSet::new(),
+            radius,
+        }
+    }
+
+    /// Calculates visible tiles from the given origin
+    pub fn calculate(&mut self, _origin: Position, _dungeon: &Dungeon) {
+        // TODO: Implement shadowcasting
+        self.visible.clear();
+    }
+
+    /// Returns true if the position is currently visible
+    pub fn is_visible(&self, pos: Position) -> bool {
+        self.visible.contains(&(pos.x, pos.y))
+    }
+
+    /// Returns true if the position has been explored
+    pub fn is_explored(&self, pos: Position) -> bool {
+        self.explored.contains(&(pos.x, pos.y))
+    }
+
+    /// Returns the number of currently visible tiles (for testing)
+    pub fn visible_count(&self) -> usize {
+        self.visible.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::tile::TileType;
+
+    /// Creates a test dungeon from ASCII layout
+    /// '#' = Wall, '.' = Floor, '>' = StairsDown
+    fn create_test_dungeon(layout: &[&str]) -> Dungeon {
+        let height = layout.len();
+        let width = layout[0].len();
+
+        let tiles: Vec<Vec<TileType>> = layout
+            .iter()
+            .map(|row| {
+                row.chars()
+                    .map(|c| match c {
+                        '#' => TileType::Wall,
+                        '.' => TileType::Floor,
+                        '>' => TileType::StairsDown,
+                        _ => TileType::Wall,
+                    })
+                    .collect()
+            })
+            .collect();
+
+        Dungeon {
+            tiles,
+            width,
+            height,
+            rooms: vec![],
+            depth: 1,
+            player_start: Position { x: 1, y: 1 },
+            stairs_position: Position { x: 1, y: 1 },
+        }
+    }
+
+    #[test]
+    fn test_fov_includes_adjacent_tiles() {
+        // 5x5 open room with player at center (2,2)
+        let dungeon = create_test_dungeon(&[
+            "#####",
+            "#...#",
+            "#...#",
+            "#...#",
+            "#####",
+        ]);
+        let mut fov = Fov::new(8);
+        fov.calculate(Position { x: 2, y: 2 }, &dungeon);
+
+        // Adjacent tiles should be visible
+        assert!(fov.is_visible(Position { x: 2, y: 1 }), "Up should be visible");
+        assert!(fov.is_visible(Position { x: 2, y: 3 }), "Down should be visible");
+        assert!(fov.is_visible(Position { x: 1, y: 2 }), "Left should be visible");
+        assert!(fov.is_visible(Position { x: 3, y: 2 }), "Right should be visible");
+    }
+
+    #[test]
+    fn test_fov_blocked_by_walls() {
+        // Room with wall in the middle
+        let dungeon = create_test_dungeon(&[
+            "#####",
+            "#...#",
+            "#.#.#",
+            "#...#",
+            "#####",
+        ]);
+        let mut fov = Fov::new(8);
+        fov.calculate(Position { x: 1, y: 2 }, &dungeon);
+
+        // Behind the wall should not be visible
+        assert!(!fov.is_visible(Position { x: 3, y: 2 }), "Behind wall should not be visible");
+        // Wall itself should be visible
+        assert!(fov.is_visible(Position { x: 2, y: 2 }), "Wall should be visible");
+    }
+
+    #[test]
+    fn test_fov_radius() {
+        // Large open area (15x15)
+        let layout: Vec<String> = (0..15)
+            .map(|y| {
+                (0..15)
+                    .map(|x| {
+                        if x == 0 || x == 14 || y == 0 || y == 14 {
+                            '#'
+                        } else {
+                            '.'
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        let layout_refs: Vec<&str> = layout.iter().map(|s| s.as_str()).collect();
+        let dungeon = create_test_dungeon(&layout_refs);
+
+        let mut fov = Fov::new(8);
+        fov.calculate(Position { x: 7, y: 7 }, &dungeon);
+
+        // Within radius 8 should be visible (distance 7 from center to edge of open area)
+        assert!(fov.is_visible(Position { x: 7, y: 1 }), "Distance 6 should be visible");
+        // The outer wall at distance 7 should be visible
+        assert!(fov.is_visible(Position { x: 7, y: 0 }), "Wall at distance 7 should be visible");
+    }
+
+    #[test]
+    fn test_explored_tiles_persist() {
+        let dungeon = create_test_dungeon(&[
+            "#######",
+            "#.....#",
+            "#.....#",
+            "#.....#",
+            "#######",
+        ]);
+        let mut fov = Fov::new(8);
+
+        // Calculate FOV from first position
+        fov.calculate(Position { x: 1, y: 2 }, &dungeon);
+        assert!(fov.is_visible(Position { x: 1, y: 1 }));
+        assert!(fov.is_explored(Position { x: 1, y: 1 }));
+
+        // Move to different position and recalculate
+        fov.calculate(Position { x: 5, y: 2 }, &dungeon);
+
+        // Previous position should no longer be visible but still explored
+        // (depending on room size, it might still be visible, so we test a corner case)
+        // In this small room, the whole room is visible, so let's check explored persists
+        assert!(fov.is_explored(Position { x: 1, y: 1 }), "Previously seen tile should remain explored");
+    }
+
+    #[test]
+    fn test_player_position_always_visible() {
+        let dungeon = create_test_dungeon(&[
+            "###",
+            "#.#",
+            "###",
+        ]);
+        let mut fov = Fov::new(8);
+        fov.calculate(Position { x: 1, y: 1 }, &dungeon);
+
+        assert!(fov.is_visible(Position { x: 1, y: 1 }), "Player position should always be visible");
+    }
+
+    #[test]
+    fn test_fov_diagonal_visibility() {
+        let dungeon = create_test_dungeon(&[
+            "#####",
+            "#...#",
+            "#...#",
+            "#...#",
+            "#####",
+        ]);
+        let mut fov = Fov::new(8);
+        fov.calculate(Position { x: 2, y: 2 }, &dungeon);
+
+        // Diagonal tiles should be visible
+        assert!(fov.is_visible(Position { x: 1, y: 1 }), "Upper-left diagonal should be visible");
+        assert!(fov.is_visible(Position { x: 3, y: 3 }), "Lower-right diagonal should be visible");
+        assert!(fov.is_visible(Position { x: 1, y: 3 }), "Lower-left diagonal should be visible");
+        assert!(fov.is_visible(Position { x: 3, y: 1 }), "Upper-right diagonal should be visible");
+    }
+
+    #[test]
+    fn test_walls_visible_but_block_view() {
+        let dungeon = create_test_dungeon(&[
+            "#####",
+            "#..##",
+            "#...#",
+            "#####",
+            "#...#",
+        ]);
+        let mut fov = Fov::new(8);
+        fov.calculate(Position { x: 1, y: 2 }, &dungeon);
+
+        // Wall row should be visible
+        assert!(fov.is_visible(Position { x: 0, y: 3 }), "Wall should be visible");
+        // Behind wall row should not be visible
+        assert!(!fov.is_visible(Position { x: 1, y: 4 }), "Behind wall should not be visible");
+    }
+}

--- a/src/world/fov.rs
+++ b/src/world/fov.rs
@@ -75,6 +75,7 @@ impl Fov {
     }
 
     /// Recursive shadowcasting for one octant
+    #[allow(clippy::too_many_arguments)]
     fn cast_light(
         &mut self,
         dungeon: &Dungeon,
@@ -183,40 +184,46 @@ mod tests {
     #[test]
     fn test_fov_includes_adjacent_tiles() {
         // 5x5 open room with player at center (2,2)
-        let dungeon = create_test_dungeon(&[
-            "#####",
-            "#...#",
-            "#...#",
-            "#...#",
-            "#####",
-        ]);
+        let dungeon = create_test_dungeon(&["#####", "#...#", "#...#", "#...#", "#####"]);
         let mut fov = Fov::new(8);
         fov.calculate(Position { x: 2, y: 2 }, &dungeon);
 
         // Adjacent tiles should be visible
-        assert!(fov.is_visible(Position { x: 2, y: 1 }), "Up should be visible");
-        assert!(fov.is_visible(Position { x: 2, y: 3 }), "Down should be visible");
-        assert!(fov.is_visible(Position { x: 1, y: 2 }), "Left should be visible");
-        assert!(fov.is_visible(Position { x: 3, y: 2 }), "Right should be visible");
+        assert!(
+            fov.is_visible(Position { x: 2, y: 1 }),
+            "Up should be visible"
+        );
+        assert!(
+            fov.is_visible(Position { x: 2, y: 3 }),
+            "Down should be visible"
+        );
+        assert!(
+            fov.is_visible(Position { x: 1, y: 2 }),
+            "Left should be visible"
+        );
+        assert!(
+            fov.is_visible(Position { x: 3, y: 2 }),
+            "Right should be visible"
+        );
     }
 
     #[test]
     fn test_fov_blocked_by_walls() {
         // Room with wall in the middle
-        let dungeon = create_test_dungeon(&[
-            "#####",
-            "#...#",
-            "#.#.#",
-            "#...#",
-            "#####",
-        ]);
+        let dungeon = create_test_dungeon(&["#####", "#...#", "#.#.#", "#...#", "#####"]);
         let mut fov = Fov::new(8);
         fov.calculate(Position { x: 1, y: 2 }, &dungeon);
 
         // Behind the wall should not be visible
-        assert!(!fov.is_visible(Position { x: 3, y: 2 }), "Behind wall should not be visible");
+        assert!(
+            !fov.is_visible(Position { x: 3, y: 2 }),
+            "Behind wall should not be visible"
+        );
         // Wall itself should be visible
-        assert!(fov.is_visible(Position { x: 2, y: 2 }), "Wall should be visible");
+        assert!(
+            fov.is_visible(Position { x: 2, y: 2 }),
+            "Wall should be visible"
+        );
     }
 
     #[test]
@@ -242,20 +249,20 @@ mod tests {
         fov.calculate(Position { x: 7, y: 7 }, &dungeon);
 
         // Within radius 8 should be visible (distance 7 from center to edge of open area)
-        assert!(fov.is_visible(Position { x: 7, y: 1 }), "Distance 6 should be visible");
+        assert!(
+            fov.is_visible(Position { x: 7, y: 1 }),
+            "Distance 6 should be visible"
+        );
         // The outer wall at distance 7 should be visible
-        assert!(fov.is_visible(Position { x: 7, y: 0 }), "Wall at distance 7 should be visible");
+        assert!(
+            fov.is_visible(Position { x: 7, y: 0 }),
+            "Wall at distance 7 should be visible"
+        );
     }
 
     #[test]
     fn test_explored_tiles_persist() {
-        let dungeon = create_test_dungeon(&[
-            "#######",
-            "#.....#",
-            "#.....#",
-            "#.....#",
-            "#######",
-        ]);
+        let dungeon = create_test_dungeon(&["#######", "#.....#", "#.....#", "#.....#", "#######"]);
         let mut fov = Fov::new(8);
 
         // Calculate FOV from first position
@@ -269,56 +276,64 @@ mod tests {
         // Previous position should no longer be visible but still explored
         // (depending on room size, it might still be visible, so we test a corner case)
         // In this small room, the whole room is visible, so let's check explored persists
-        assert!(fov.is_explored(Position { x: 1, y: 1 }), "Previously seen tile should remain explored");
+        assert!(
+            fov.is_explored(Position { x: 1, y: 1 }),
+            "Previously seen tile should remain explored"
+        );
     }
 
     #[test]
     fn test_player_position_always_visible() {
-        let dungeon = create_test_dungeon(&[
-            "###",
-            "#.#",
-            "###",
-        ]);
+        let dungeon = create_test_dungeon(&["###", "#.#", "###"]);
         let mut fov = Fov::new(8);
         fov.calculate(Position { x: 1, y: 1 }, &dungeon);
 
-        assert!(fov.is_visible(Position { x: 1, y: 1 }), "Player position should always be visible");
+        assert!(
+            fov.is_visible(Position { x: 1, y: 1 }),
+            "Player position should always be visible"
+        );
     }
 
     #[test]
     fn test_fov_diagonal_visibility() {
-        let dungeon = create_test_dungeon(&[
-            "#####",
-            "#...#",
-            "#...#",
-            "#...#",
-            "#####",
-        ]);
+        let dungeon = create_test_dungeon(&["#####", "#...#", "#...#", "#...#", "#####"]);
         let mut fov = Fov::new(8);
         fov.calculate(Position { x: 2, y: 2 }, &dungeon);
 
         // Diagonal tiles should be visible
-        assert!(fov.is_visible(Position { x: 1, y: 1 }), "Upper-left diagonal should be visible");
-        assert!(fov.is_visible(Position { x: 3, y: 3 }), "Lower-right diagonal should be visible");
-        assert!(fov.is_visible(Position { x: 1, y: 3 }), "Lower-left diagonal should be visible");
-        assert!(fov.is_visible(Position { x: 3, y: 1 }), "Upper-right diagonal should be visible");
+        assert!(
+            fov.is_visible(Position { x: 1, y: 1 }),
+            "Upper-left diagonal should be visible"
+        );
+        assert!(
+            fov.is_visible(Position { x: 3, y: 3 }),
+            "Lower-right diagonal should be visible"
+        );
+        assert!(
+            fov.is_visible(Position { x: 1, y: 3 }),
+            "Lower-left diagonal should be visible"
+        );
+        assert!(
+            fov.is_visible(Position { x: 3, y: 1 }),
+            "Upper-right diagonal should be visible"
+        );
     }
 
     #[test]
     fn test_walls_visible_but_block_view() {
-        let dungeon = create_test_dungeon(&[
-            "#####",
-            "#..##",
-            "#...#",
-            "#####",
-            "#...#",
-        ]);
+        let dungeon = create_test_dungeon(&["#####", "#..##", "#...#", "#####", "#...#"]);
         let mut fov = Fov::new(8);
         fov.calculate(Position { x: 1, y: 2 }, &dungeon);
 
         // Wall row should be visible
-        assert!(fov.is_visible(Position { x: 0, y: 3 }), "Wall should be visible");
+        assert!(
+            fov.is_visible(Position { x: 0, y: 3 }),
+            "Wall should be visible"
+        );
         // Behind wall row should not be visible
-        assert!(!fov.is_visible(Position { x: 1, y: 4 }), "Behind wall should not be visible");
+        assert!(
+            !fov.is_visible(Position { x: 1, y: 4 }),
+            "Behind wall should not be visible"
+        );
     }
 }


### PR DESCRIPTION
## 概要

プレイヤーの視野（FOV: Field of View）システムを実装し、ローグライクらしい探索感を実現します。

## 関連Issue

- Closes #3

## 変更内容

- Recursive Shadowcastingアルゴリズムによる視野計算を実装
- 可視/探索済み/未探索の3状態でタイルを描画
- プレイヤー移動時および階層移動時にFOVを更新
- `is_transparent()` メソッドをDungeonに追加

## 関連フェーズ

- [ ] フェーズ1: 基盤（構造、描画、移動）
- [ ] フェーズ2: ランダム生成（ダンジョン生成）
- [x] フェーズ3: FOV（視野、探索）
- [ ] フェーズ4: 敵（妖怪、AI）
- [ ] フェーズ5: 戦闘（ターンシステム、戦闘、レベルアップ）
- [ ] フェーズ6: 符術（符術システム）
- [ ] フェーズ7: アイテム（インベントリ、アイテム）
- [ ] その他

## テスト

- [x] 新規テストを追加した
- [ ] 既存テストを更新した
- [ ] テスト不要（理由: ）

### 追加/更新したテスト

- `test_fov_includes_adjacent_tiles` - FOVに隣接タイルが含まれる
- `test_fov_blocked_by_walls` - 壁によってFOVがブロックされる
- `test_fov_radius` - FOV半径が正しい
- `test_explored_tiles_persist` - 探索済みタイルが保持される
- `test_player_position_always_visible` - プレイヤー位置は常に見える
- `test_fov_diagonal_visibility` - 斜め方向の可視性
- `test_walls_visible_but_block_view` - 壁は見えるが視線を遮る
- `test_wall_not_transparent` - 壁は透過しない
- `test_floor_transparent` - 床は透過する
- `test_stairs_transparent` - 階段は透過する
- `test_outside_bounds_not_transparent` - 境界外は透過しない

## チェックリスト

- [x] `cargo test` がパス
- [x] `cargo clippy` がパス
- [x] `cargo fmt` を適用済み
- [x] CLAUDE.md のガイドラインに従っている
- [ ] 破壊的変更がある場合は明記した

## スクリーンショット/動作確認

`cargo run` で実行すると以下を確認できます:
- プレイヤー周辺のみ明るく表示される
- 壁の後ろは見えない
- 移動すると視野が更新される
- 一度見た場所は暗い灰色で表示される

## 追加メモ

- FOV半径は8タイル（`FOV_RADIUS`定数で設定）
- シャドウキャスティングアルゴリズムは8つのoctantに分割して計算
- 探索済みタイルは階層を移動してもリセットされる（新しい階層では未探索状態から開始）

🤖 Generated with [Claude Code](https://claude.com/claude-code)